### PR TITLE
fill_mem: correct optional parameter number check

### DIFF
--- a/pci_debug.c
+++ b/pci_debug.c
@@ -636,7 +636,7 @@ int fill_mem(device_t *dev, char *cmd)
 		}
 	} else {
 		status = sscanf(cmd, "%*c%d %x %x %x %x", &width, &addr, &d32, &len, &inc);
-		if ((status != 3) && (status != 4)) {
+		if ((status != 4) && (status != 5)) {
 			printf("Syntax error (use ? for help)\n");
 			/* Don't break out of command processing loop */
 			return 0;


### PR DESCRIPTION
When using f[width] operation, the optional parameter number is 4 or 5.
```status = sscanf(cmd, "%*c%d %x %x %x %x", &width, &addr, &d32, &len, &inc);```